### PR TITLE
Make project depend on `requests` module

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ install_requires = [
     "WebHelpers2",
     "tgscheduler",
     "filedepot",
+    "requests"
 ]
 
 if py_version != (3, 2):


### PR DESCRIPTION
It is used in the project but is not listed as a dependency, so those who run `pip install -e . --user` will hit a wall if they don't have it installed elsewhere.