### PR TITLE
add WikiPage to public model symbols

### DIFF
--- a/acmwebsite/model/__init__.py
+++ b/acmwebsite/model/__init__.py
@@ -64,4 +64,4 @@ from acmwebsite.model.mailmessage import MailMessage
 from acmwebsite.model.survey import Survey, SurveyField, SurveyResponse, SurveyData
 from acmwebsite.model.wikipage import WikiPage
 
-__all__ = ('User', 'Group', 'Permission', 'Meeting', 'MailMessage', 'Survey', 'SurveyField', 'SurveyResponse', 'SurveyData')
+__all__ = ('User', 'Group', 'Permission', 'Meeting', 'MailMessage', 'Survey', 'SurveyField', 'SurveyResponse', 'SurveyData', 'WikiPage')


### PR DESCRIPTION
Looks like a bug because WikiPage is imported but never used. Could be wrong, and if so reject (obviously).