### PR TITLE
Graphical survey results page

### DIFF
--- a/acmwebsite/controllers/survey.py
+++ b/acmwebsite/controllers/survey.py
@@ -18,14 +18,15 @@ class SurveyController(BaseController):
     def __init__(self, survey):
         self.survey = survey
 
-    @expose('json')
+    @expose('acmwebsite.templates.survey_results')
     @require(has_permission('admin'))
     def results(self, number=None):
         responses = self.survey.responses or []
         responses = [response_to_dict(r) for r in responses]
         return {
+            'survey': self.survey,
             'count': len(responses),
-            'responses': responses, 
+            'responses': responses,
             'fields': survey_fields(self.survey),
         }
 

--- a/acmwebsite/controllers/survey.py
+++ b/acmwebsite/controllers/survey.py
@@ -1,26 +1,8 @@
-from tg import expose, redirect, flash, abort, require, request
+from tg import abort, expose, flash, redirect, request, require
 from tg.predicates import has_permission
 
 from acmwebsite.lib.base import BaseController
-from acmwebsite.model import DBSession, Survey, SurveyResponse, SurveyData
-
-
-def response_dict(response, fields):
-    out = {
-        'name': response.name,
-        'email': response.email,
-    }
-
-    # Populate with the default value for the fields. This is necessary for
-    # sorting if some respondents didn't fill out an optional field.
-    for field in fields:
-        out[field.name] = field.type_object().default()
-
-    # Override with the actual response data for the fields that exist.
-    for item in response.data:
-        out[item.field.name] = item.field.type_object().from_contents(item.contents)
-
-    return out
+from acmwebsite.model import DBSession, Survey, SurveyData, SurveyResponse
 
 
 class SurveyController(BaseController):
@@ -33,24 +15,53 @@ class SurveyController(BaseController):
         if type(reverse) is str:
             reverse = reverse == 'True'
 
-        responses = self.survey.responses or []
-        responses = [response_dict(r, self.survey.fields) for r in responses]
+        responses = self._survey_responses()
         if order_by:
-            responses = sorted(responses,
-                               key=lambda x: x.get(order_by),
-                               reverse=reverse)
+            responses.sort(key=lambda x: x.get(order_by), reverse=reverse)
 
+        survey_title = (self.survey.title or
+                        (self.survey.meeting and self.survey.meeting.title) or
+                        'Survey')
         return {
             'survey': self.survey,
-            'title': (self.survey.title or
-                      (self.survey.meeting and self.survey.meeting.title) or
-                      'Survey'),
+            'title': survey_title,
             'count': len(responses),
             'responses': responses,
             'fields': self.survey.field_metadata(),
             'order_by': order_by,
             'reverse': reverse,
         }
+
+    @expose('json')
+    @require(has_permission('admin'))
+    def results_json(self, number=None):
+        responses = self._survey_responses()
+        return {
+            'count': len(responses),
+            'responses': responses,
+            'fields': self.survey.field_metadata(),
+        }
+
+    def _response_dict(self, response):
+        out = {'name': response.name, 'email': response.email}
+
+        # Populate with the default value for the fields. This is necessary for
+        # sorting if some respondents didn't fill out an optional field.
+        for field in self.survey.fields:
+            out[field.name] = field.type_object().default()
+
+        # Override with the actual response data for the fields that exist.
+        out.update({
+            item.field.name:
+            item.field.type_object().from_contents(item.contents)
+            for item in response.data
+        })
+
+        return out
+
+    def _survey_responses(self):
+        responses = self.survey.responses or []
+        return [self._response_dict(r) for r in responses]
 
     @expose('acmwebsite.templates.survey')
     def respond(self):
@@ -61,14 +72,16 @@ class SurveyController(BaseController):
             if not has_permission('admin'):
                 abort(403, 'Survey not avalible')
                 return
-            flash('This page is currently disabled. You can see it because you are an admin.', 'warn')
+            flash('This page is currently disabled. You can see it because you are an admin.',
+                  'warn')
 
         form = request.POST
         if form:
             user = request.identity and request.identity.get('user')
-            response = SurveyResponse(user=user,
-                                      provided_name=form.get('_provided_name'),
-                                      survey=self.survey)
+            response = SurveyResponse(
+                user=user,
+                provided_name=form.get('_provided_name'),
+                survey=self.survey)
             DBSession.add(response)
 
             requires_ft = bool(form.get('first_time'))
@@ -79,7 +92,8 @@ class SurveyController(BaseController):
                 fo = f.type_object()
                 v = fo.from_post(form)
                 if v:
-                    DBSession.add(SurveyData(response=response, field=f, contents=v))
+                    DBSession.add(
+                        SurveyData(response=response, field=f, contents=v))
             flash('Response submitted successfully')
             redirect(base_url='/')
         else:

--- a/acmwebsite/lib/helpers.py
+++ b/acmwebsite/lib/helpers.py
@@ -85,6 +85,10 @@ def field_cn(ty, *args):
     return ' '.join(args)
 
 
+def order_by_link(column, current_order_by, reverse):
+    reverse = current_order_by == column and not reverse
+    return '?order_by={}&reverse={}'.format(column, reverse)
+
 # Import commonly used helpers from WebHelpers2 and TG
 from tg.util.html import script_json_encode
 

--- a/acmwebsite/lib/surveytypes.py
+++ b/acmwebsite/lib/surveytypes.py
@@ -47,7 +47,7 @@ class Text(SurveyType):
         return contents
 
     def default(self):
-        return ''
+        return self.value or ''
 
 
 class ShortText(Text):
@@ -88,7 +88,7 @@ class OneOf(SurveyType):
         return contents
 
     def default(self):
-        return ''
+        return self.value or ''
 
 
 class Select(SurveyType):

--- a/acmwebsite/lib/surveytypes.py
+++ b/acmwebsite/lib/surveytypes.py
@@ -1,5 +1,6 @@
 from ast import literal_eval
 
+
 class SurveyType:
     def __init__(self, name, label=None, required=False, first_time=False, **kwargs):
         self.name = name
@@ -14,6 +15,10 @@ class SurveyType:
     def from_contents(self, contents):
         return literal_eval(contents)
 
+    def default(self):
+        raise NotImplementedError('Descendants of SurveyType must implement default()')
+
+
 class Bool(SurveyType):
     template = 'checkbox'
 
@@ -23,6 +28,10 @@ class Bool(SurveyType):
 
     def from_post(self, form):
         return str(bool(form.get(self.name)))
+
+    def default(self):
+        return False
+
 
 class Text(SurveyType):
     def __init__(self, value='', placeholder=None, **kwargs):
@@ -37,11 +46,17 @@ class Text(SurveyType):
     def from_contents(self, contents):
         return contents
 
+    def default(self):
+        return ''
+
+
 class ShortText(Text):
     template = 'text'
 
+
 class LongText(Text):
     template = 'textarea'
+
 
 class ManyOf(SurveyType):
     template = 'checkbox_group'
@@ -53,6 +68,10 @@ class ManyOf(SurveyType):
     def from_post(self, form):
         vals = [n for i, n in enumerate(self.options) if form.get('{}_{}'.format(self.name, i))]
         return str(vals)
+
+    def default(self):
+        return ''
+
 
 class OneOf(SurveyType):
     template = 'radio_group'
@@ -67,6 +86,10 @@ class OneOf(SurveyType):
 
     def from_contents(self, contents):
         return contents
+
+    def default(self):
+        return ''
+
 
 class Select(SurveyType):
     template = 'select'
@@ -83,11 +106,19 @@ class Select(SurveyType):
     def from_contents(self, contents):
         return contents
 
+    def default(self):
+        return self.value or ''
+
+
 class SelectMany(Select):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self.multiple = True
- 
+
+    def default(self):
+        return ''
+
+
 class Number(SurveyType):
     template = 'number'
 
@@ -104,4 +135,12 @@ class Number(SurveyType):
             return None
         return repr(float(v))
 
-types = {k: v for k, v in globals().items() if isinstance(v, type) and issubclass(v, SurveyType)}
+    def default(self):
+        return self.value or 0
+
+
+types = {
+    k: v
+    for k, v in globals().items()
+    if isinstance(v, type) and issubclass(v, SurveyType)
+}

--- a/acmwebsite/model/survey.py
+++ b/acmwebsite/model/survey.py
@@ -13,7 +13,7 @@ from ast import literal_eval
 survey_field_table = Table('survey_field', metadata,
                            Column('survey_id', Integer, ForeignKey('survey.id'), primary_key=True),
                            Column('field_id', Integer, ForeignKey('field.id'), primary_key=True)
-)
+                           )
 
 class Survey(DeclarativeBase):
     __tablename__ = 'survey'
@@ -29,6 +29,10 @@ class Survey(DeclarativeBase):
     def active(self):
         now = datetime.now()
         return self.opens and self.opens < now and (not self.closes or self.closes > now)
+
+    def field_metadata(self):
+        return [{'name': f.name, 'type': f.type} for f in self.fields]
+
 
 class SurveyField(DeclarativeBase):
     __tablename__ = 'field'

--- a/acmwebsite/model/survey.py
+++ b/acmwebsite/model/survey.py
@@ -1,26 +1,28 @@
-from sqlalchemy import *
-from sqlalchemy.orm import mapper, relation, relationship, backref
-from sqlalchemy import Table, ForeignKey, Column
-from sqlalchemy.types import Integer, String, Unicode
-
 from datetime import datetime
 
-from acmwebsite.model import DeclarativeBase, metadata, DBSession
+from sqlalchemy import Boolean, Column, DateTime, Float, ForeignKey, Table
+from sqlalchemy.orm import relation
+from sqlalchemy.types import Integer, String, Unicode
+
 from acmwebsite.lib.surveytypes import types
+from acmwebsite.model import DeclarativeBase, metadata
 
-from ast import literal_eval
+survey_field_table = Table(
+    'survey_field', metadata,
+    Column('survey_id', Integer, ForeignKey('survey.id'), primary_key=True),
+    Column('field_id', Integer, ForeignKey('field.id'), primary_key=True))
 
-survey_field_table = Table('survey_field', metadata,
-                           Column('survey_id', Integer, ForeignKey('survey.id'), primary_key=True),
-                           Column('field_id', Integer, ForeignKey('field.id'), primary_key=True)
-                           )
 
 class Survey(DeclarativeBase):
     __tablename__ = 'survey'
 
     id = Column(Integer, autoincrement=True, primary_key=True)
     meeting = relation('Meeting', back_populates='survey', uselist=False)
-    fields = relation('SurveyField', secondary=survey_field_table, backref='surveys', order_by='SurveyField.priority')
+    fields = relation(
+        'SurveyField',
+        secondary=survey_field_table,
+        backref='surveys',
+        order_by='SurveyField.priority')
     title = Column(Unicode)
     opens = Column(DateTime)
     closes = Column(DateTime)
@@ -51,7 +53,6 @@ class SurveyField(DeclarativeBase):
     max = Column(Float)
     step = Column(Float)
 
-
     def type_object(self):
         return types[self.type](
             name=self.name,
@@ -65,6 +66,7 @@ class SurveyField(DeclarativeBase):
             max=self.max,
             step=self.step,
         )
+
 
 class SurveyResponse(DeclarativeBase):
     __tablename__ = 'response'

--- a/acmwebsite/templates/survey_results.xhtml
+++ b/acmwebsite/templates/survey_results.xhtml
@@ -1,0 +1,34 @@
+<html py:strip=""
+  xmlns:py="http://genshi.edgewall.org/"
+  xmlns:xi="http://www.w3.org/2001/XInclude"
+  py:extends="master.xhtml">
+
+  <head py:block="head" py:strip="True">
+    <title>Mines ACM - Survey</title>
+  </head>
+
+  <div py:def="unknown_type(ty)">
+    Unknown survey field! 
+  </div>
+
+  <body py:block="body" py:strip="True">
+    <py:import href="acmwebsite.templates.survey_components" alias="comp" />
+
+    <h1 class="page-header">${survey.title or (survey.meeting and survey.meeting.title) or 'Survey'}</h1>
+    <h2>Responses</h2>
+    <div class="row">
+      <table class="table">
+        <thead>
+          <tr>
+            <th py:for="field in fields" py:content="field['name']" />
+          </tr>
+        </thead>
+        <tbody>
+          <tr py:for="r in responses">
+            <td py:content="r['name']" />
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </body>
+</html>

--- a/acmwebsite/templates/survey_results.xhtml
+++ b/acmwebsite/templates/survey_results.xhtml
@@ -4,12 +4,8 @@
   py:extends="master.xhtml">
 
   <head py:block="head" py:strip="True">
-    <title>Mines ACM - Survey</title>
+    <title>Mines ACM - Survey ${survey.id} Responses</title>
   </head>
-
-  <div py:def="unknown_type(ty)">
-    Unknown survey field!
-  </div>
 
   <body py:block="body" py:strip="True">
     <py:import href="acmwebsite.templates.survey_components" alias="comp" />
@@ -19,6 +15,10 @@
     <div class="row">
       <div class="col-md-12">
         <table class="table table-striped table-condensed table-bordered">
+          <!--
+          I'm doing some fancy shenanigans here to allow the user to sort by
+          each column ascending and descending.
+          -->
           <thead>
             <tr>
               <th>

--- a/acmwebsite/templates/survey_results.xhtml
+++ b/acmwebsite/templates/survey_results.xhtml
@@ -8,27 +8,40 @@
   </head>
 
   <div py:def="unknown_type(ty)">
-    Unknown survey field! 
+    Unknown survey field!
   </div>
 
   <body py:block="body" py:strip="True">
     <py:import href="acmwebsite.templates.survey_components" alias="comp" />
 
-    <h1 class="page-header">${survey.title or (survey.meeting and survey.meeting.title) or 'Survey'}</h1>
+    <h1 class="page-header" py:content="title" />
     <h2>Responses</h2>
     <div class="row">
-      <table class="table">
-        <thead>
-          <tr>
-            <th py:for="field in fields" py:content="field['name']" />
-          </tr>
-        </thead>
-        <tbody>
-          <tr py:for="r in responses">
-            <td py:content="r['name']" />
-          </tr>
-        </tbody>
-      </table>
+      <div class="col-md-12">
+        <table class="table table-striped table-condensed table-bordered">
+          <thead>
+            <tr>
+              <th>
+                <a href="${h.order_by_link('name', order_by, reverse)}">Name</a>
+                <span py:if="order_by == 'name'"
+                  py:content="h.icon('triangle-%s' % ('top' if reverse else 'bottom'))" />
+              </th>
+              <th py:for="field in fields">
+                <a href="${h.order_by_link(field['name'], order_by, reverse)}"
+                  py:content="field['name']" />
+                <span py:if="order_by == field['name']"
+                  py:content="h.icon('triangle-%s' % ('top' if reverse else 'bottom'))" />
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr py:for="r in responses">
+              <td py:content="r['name']" />
+              <td py:for="field in fields" py:content="r.get(field['name'])" />
+            </tr>
+          </tbody>
+        </table>
+      </div>
     </div>
   </body>
 </html>


### PR DESCRIPTION
Resolves #18 

# Features

- `/s/#/results` endpoint goes to the results table.
- You can sort the results by any of the columns by clicking on the links in the headers (like on the admin page).
- The old JSON endpoint has been moved to `/s/#/results_json`.

Here's a picture of what this looks like on my local copy:

![2017-12-15-15 07 31](https://user-images.githubusercontent.com/16734772/34062409-ac9467e2-e1a9-11e7-96d5-42dcae2c2646.png)

